### PR TITLE
Accessibility: Assign mnemonic widgets for gesture labels

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -62,6 +62,9 @@ class Main(Gtk.Window):
             textbox.set_width_chars(30)
             textbox.set_placeholder_text("Command")
             textbox.set_tooltip_text("Enter the command to execute for this gesture. Hint: Can concatenate multiple commands with '&&'")
+
+            label_widget.set_mnemonic_widget(textbox)
+
             self.grid.attach(label_widget, 0, i+1, 1, 1)
             self.grid.attach_next_to(textbox, label_widget, Gtk.PositionType.RIGHT, 1, 1)
             self.text_entries[label] = textbox


### PR DESCRIPTION
In order to present an interactable element such as button, checkbox, etc. to the user while navigating by pressing the tab key, screenreaders extract information about the focused widget and read aloud the relevant information (widget description, type, state, ...). However, while some widgets (such as buttons) carry apparent description labels with them, some (like textboxes) don't feature descriptive labels on their own, visually, developers usually denote their purpose by placing a description label next to the textbox, however this is a purely visual solution and there is no semantic link between the two that the screenreader could detect and reliably interpret. GTK Label does carry a set_mnemonic_widget function, which can be used to assign the label to any widget so a screenreader would notice it during keyboard navigation and read it properly.

Specifically in case of GestureX, this commit assigns the labels of gesture command textboxes to their respective entries, so a blind user would get to hear what gesture are they assigning a command to.

## Reproduction steps

1. With a setup dev environment, launch gui.py
2. Turn on the Orca screenreader (Alt+Super+S on most distributions)
3. Press the Tab key to move around the interface, particularly the gesture textboxes

### Original behavior

Text entries were announced with their placeholder texts, however without information on what gesture are they related to

### New behavior

When landing on a gesture textbox, its respective label is properly announced by the screenreader
