### PR TITLE
Fix debian installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,3 +112,9 @@ This project utilizes the following libraries:
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 
+# Installation Problems
+
+## Debian
+
+If pip won't install PyGObject because pycairo is missing, you should check if you have the `libgtk-4-dev` package installed.
+If python complains about missing `cv2`, you'll need the `python3-opencv` package. Afterwards rebuild the venv.

--- a/gui.py
+++ b/gui.py
@@ -1,9 +1,9 @@
+import mediapipe as mp
 import gi
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk, GdkPixbuf, Gdk, GLib
 import cv2
 import numpy as np
-import mediapipe as mp
 from keras.models import load_model
 import threading
 import os


### PR DESCRIPTION
When installing on Debian, there are some packages that need to be there. Added notes for those in the newly added "Installation Problems" section.

Additionally, it didn't work for me when I left the imports as they were, so I moved mediapipe up and now it works flawlessly.